### PR TITLE
add client_id  as method to identify end-user in signOut

### DIFF
--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -451,23 +451,24 @@ class OpenIDConnectClient
      *
      * @throws OpenIDConnectClientException
      */
-    public function signOut($enduserIdentification, $redirect, $method = "id_token_hint") {
-        if (!in_array($method, array("id_token_hint", "login_hint")))
-            throw new OpenIDConnectClientException('method must be "id_token_hint" or "login_hint"');
+    public function signOut($enduserIdentification, $redirect, $method = "id_token_hint")
+    {
+        if (!in_array($method, array("id_token_hint", "login_hint", "client_id")))
+            throw new OpenIDConnectClientException('method must be "id_token_hint" or "login_hint" or "client_id"');
 
         $signout_endpoint = $this->getProviderConfigValue("end_session_endpoint");
 
         $signout_params = null;
-        if($redirect === null){
+        if ($redirect === null) {
             $signout_params = array($method => $enduserIdentification);
-        }
-        else {
+        } else {
             $signout_params = array(
                 $method => $enduserIdentification,
-                'post_logout_redirect_uri' => $redirect);
+                'post_logout_redirect_uri' => $redirect,
+            );
         }
 
-        $signout_endpoint  .= (strpos($signout_endpoint, '?') === false ? '?' : '&') . http_build_query( $signout_params, '', '&', $this->enc_type);
+        $signout_endpoint  .= (strpos($signout_endpoint, '?') === false ? '?' : '&') . http_build_query($signout_params, '', '&', $this->enc_type);
         $this->redirect($signout_endpoint);
     }
 

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  *
  * Copyright MITRE 2020
@@ -42,8 +41,7 @@ if (!class_exists('\phpseclib\Crypt\RSA') && !class_exists('Crypt_RSA')) {
  * @param string $base64url
  * @return bool|string
  */
-function base64url_decode($base64url)
-{
+function base64url_decode($base64url) {
     return base64_decode(b64url2b64($base64url));
 }
 
@@ -55,8 +53,7 @@ function base64url_decode($base64url)
  * @param string $base64url
  * @return string
  */
-function b64url2b64($base64url)
-{
+function b64url2b64($base64url) {
     // "Shouldn't" be necessary, but why not
     $padding = strlen($base64url) % 4;
     if ($padding > 0) {
@@ -69,7 +66,10 @@ function b64url2b64($base64url)
 /**
  * OpenIDConnect Exception Class
  */
-class OpenIDConnectClientException extends \Exception {}
+class OpenIDConnectClientException extends \Exception
+{
+
+}
 
 /**
  * Require the CURL and JSON PHP extensions to be installed
@@ -244,8 +244,7 @@ class OpenIDConnectClient
      * @param $client_secret string optional
      * @param null $issuer
      */
-    public function __construct($provider_url = null, $client_id = null, $client_secret = null, $issuer = null)
-    {
+    public function __construct($provider_url = null, $client_id = null, $client_secret = null, $issuer = null) {
         $this->setProviderURL($provider_url);
         if ($issuer === null) {
             $this->setIssuer($provider_url);
@@ -256,32 +255,29 @@ class OpenIDConnectClient
         $this->clientID = $client_id;
         $this->clientSecret = $client_secret;
 
-        $this->issuerValidator = function ($iss) {
-            return ($iss === $this->getIssuer() || $iss === $this->getWellKnownIssuer() || $iss === $this->getWellKnownIssuer(true));
+        $this->issuerValidator = function($iss){
+	        return ($iss === $this->getIssuer() || $iss === $this->getWellKnownIssuer() || $iss === $this->getWellKnownIssuer(true));
         };
     }
 
     /**
      * @param $provider_url
      */
-    public function setProviderURL($provider_url)
-    {
+    public function setProviderURL($provider_url) {
         $this->providerConfig['providerUrl'] = $provider_url;
     }
 
     /**
      * @param $issuer
      */
-    public function setIssuer($issuer)
-    {
+    public function setIssuer($issuer) {
         $this->providerConfig['issuer'] = $issuer;
     }
 
     /**
      * @param $response_types
      */
-    public function setResponseTypes($response_types)
-    {
+    public function setResponseTypes($response_types) {
         $this->responseTypes = array_merge($this->responseTypes, (array)$response_types);
     }
 
@@ -289,13 +285,12 @@ class OpenIDConnectClient
      * @return bool
      * @throws OpenIDConnectClientException
      */
-    public function authenticate()
-    {
+    public function authenticate() {
 
         // Do a preemptive check to see if the provider has thrown an error from a previous redirect
         if (isset($_REQUEST['error'])) {
             $desc = isset($_REQUEST['error_description']) ? ' Description: ' . $_REQUEST['error_description'] : '';
-            throw new OpenIDConnectClientException('Error: ' . $_REQUEST['error'] . $desc);
+            throw new OpenIDConnectClientException('Error: ' . $_REQUEST['error'] .$desc);
         }
 
         // If we have an authorization code then proceed to request a token
@@ -316,7 +311,7 @@ class OpenIDConnectClient
             // and the authentication process fail
             if ($this->getState() == "")
                 $this->setState($_REQUEST['state']);
-
+            
             // Do an OpenID Connect session check
             if ($_REQUEST['state'] !== $this->getState()) {
                 throw new OpenIDConnectClientException('Unable to determine state');
@@ -334,10 +329,10 @@ class OpenIDConnectClient
             // Verify the signature
             if ($this->canVerifySignatures()) {
                 if (!$this->getProviderConfigValue('jwks_uri')) {
-                    throw new OpenIDConnectClientException('Unable to verify signature due to no jwks_uri being defined');
+                    throw new OpenIDConnectClientException ('Unable to verify signature due to no jwks_uri being defined');
                 }
                 if (!$this->verifyJWTsignature($token_json->id_token)) {
-                    throw new OpenIDConnectClientException('Unable to verify signature');
+                    throw new OpenIDConnectClientException ('Unable to verify signature');
                 }
             } else {
                 user_error('Warning: JWT signature verification unavailable.');
@@ -355,7 +350,7 @@ class OpenIDConnectClient
                 $this->setNonce($claims->nonce);
                 user_error('Warning: Function getNonce return empty, setting in the session!');
             };
-
+            
             // If this is a valid claim
             if ($this->verifyJWTclaims($claims, $token_json->access_token)) {
 
@@ -375,9 +370,10 @@ class OpenIDConnectClient
 
                 // Success!
                 return true;
+
             }
 
-            throw new OpenIDConnectClientException('Unable to verify JWT claims');
+            throw new OpenIDConnectClientException ('Unable to verify JWT claims');
         }
 
         if ($this->allowImplicitFlow && isset($_REQUEST['id_token'])) {
@@ -402,10 +398,10 @@ class OpenIDConnectClient
             // Verify the signature
             if ($this->canVerifySignatures()) {
                 if (!$this->getProviderConfigValue('jwks_uri')) {
-                    throw new OpenIDConnectClientException('Unable to verify signature due to no jwks_uri being defined');
+                    throw new OpenIDConnectClientException ('Unable to verify signature due to no jwks_uri being defined');
                 }
                 if (!$this->verifyJWTsignature($id_token)) {
-                    throw new OpenIDConnectClientException('Unable to verify signature');
+                    throw new OpenIDConnectClientException ('Unable to verify signature');
                 }
             } else {
                 user_error('Warning: JWT signature verification unavailable.');
@@ -430,13 +426,15 @@ class OpenIDConnectClient
 
                 // Success!
                 return true;
+
             }
 
-            throw new OpenIDConnectClientException('Unable to verify JWT claims');
+            throw new OpenIDConnectClientException ('Unable to verify JWT claims');
         }
 
         $this->requestAuthorization();
         return false;
+
     }
 
     /**
@@ -453,56 +451,51 @@ class OpenIDConnectClient
      *
      * @throws OpenIDConnectClientException
      */
-    public function signOut($enduserIdentification, $redirect, $method = "id_token_hint")
-    {
-        if (!in_array($method, array("id_token_hint", "login_hint", "client_id")))
-            throw new OpenIDConnectClientException('method must be "id_token_hint" or "login_hint" or "client_id"');
+    public function signOut($enduserIdentification, $redirect, $method = "id_token_hint") {
+        if (!in_array($method, array("id_token_hint", "login_hint")))
+            throw new OpenIDConnectClientException('method must be "id_token_hint" or "login_hint"');
 
         $signout_endpoint = $this->getProviderConfigValue("end_session_endpoint");
 
         $signout_params = null;
-        if ($redirect === null) {
+        if($redirect === null){
             $signout_params = array($method => $enduserIdentification);
-        } else {
+        }
+        else {
             $signout_params = array(
                 $method => $enduserIdentification,
-                'post_logout_redirect_uri' => $redirect,
-            );
+                'post_logout_redirect_uri' => $redirect);
         }
 
-        $signout_endpoint  .= (strpos($signout_endpoint, '?') === false ? '?' : '&') . http_build_query($signout_params, '', '&', $this->enc_type);
+        $signout_endpoint  .= (strpos($signout_endpoint, '?') === false ? '?' : '&') . http_build_query( $signout_params, '', '&', $this->enc_type);
         $this->redirect($signout_endpoint);
     }
 
     /**
      * @param array $scope - example: openid, given_name, etc...
      */
-    public function addScope($scope)
-    {
+    public function addScope($scope) {
         $this->scopes = array_merge($this->scopes, (array)$scope);
     }
 
     /**
      * @param array $param - example: prompt=login
      */
-    public function addAuthParam($param)
-    {
+    public function addAuthParam($param) {
         $this->authParams = array_merge($this->authParams, (array)$param);
     }
 
     /**
      * @param array $param - example: post_logout_redirect_uris=[http://example.com/successful-logout]
      */
-    public function addRegistrationParam($param)
-    {
+    public function addRegistrationParam($param) {
         $this->registrationParams = array_merge($this->registrationParams, (array)$param);
     }
 
     /**
      * @param $jwk object - example: (object) array('kid' => ..., 'nbf' => ..., 'use' => 'sig', 'kty' => "RSA", 'e' => "", 'n' => "")
      */
-    protected function addAdditionalJwk($jwk)
-    {
+    protected function addAdditionalJwk($jwk) {
         $this->additionalJwks[] = $jwk;
     }
 
@@ -515,8 +508,7 @@ class OpenIDConnectClient
      * @return string
      *
      */
-    protected function getProviderConfigValue($param, $default = null)
-    {
+    protected function getProviderConfigValue($param, $default = null) {
 
         // If the configuration value is not available, attempt to fetch it from a well known config endpoint
         // This is also known as auto "discovery"
@@ -536,21 +528,20 @@ class OpenIDConnectClient
      * @return string
      *
      */
-    private function getWellKnownConfigValue($param, $default = null)
-    {
+    private function getWellKnownConfigValue($param, $default = null) {
 
         // If the configuration value is not available, attempt to fetch it from a well known config endpoint
         // This is also known as auto "discovery"
-        if (!$this->wellKnown) {
+        if(!$this->wellKnown) {
             $well_known_config_url = rtrim($this->getProviderURL(), '/') . '/.well-known/openid-configuration';
-            if (count($this->wellKnownConfigParameters) > 0) {
-                $well_known_config_url .= '?' .  http_build_query($this->wellKnownConfigParameters);
+            if (count($this->wellKnownConfigParameters) > 0){
+                $well_known_config_url .= '?' .  http_build_query($this->wellKnownConfigParameters) ;
             }
             $this->wellKnown = json_decode($this->fetchURL($well_known_config_url));
         }
 
         $value = false;
-        if (isset($this->wellKnown->{$param})) {
+        if(isset($this->wellKnown->{$param})){
             $value = $this->wellKnown->{$param};
         }
 
@@ -572,18 +563,16 @@ class OpenIDConnectClient
      * @param string $param
      *
      */
-    public function setWellKnownConfigParameters(array $params = [])
-    {
-        $this->wellKnownConfigParameters = $params;
+    public function setWellKnownConfigParameters(array $params = []){
+        $this->wellKnownConfigParameters=$params;
     }
 
 
     /**
      * @param string $url Sets redirect URL for auth flow
      */
-    public function setRedirectURL($url)
-    {
-        if (parse_url($url, PHP_URL_HOST) !== false) {
+    public function setRedirectURL ($url) {
+        if (parse_url($url,PHP_URL_HOST) !== false) {
             $this->redirectURL = $url;
         }
     }
@@ -593,8 +582,7 @@ class OpenIDConnectClient
      *
      * @return string
      */
-    public function getRedirectURL()
-    {
+    public function getRedirectURL() {
 
         // If the redirect URL has been set then return it.
         if (property_exists($this, 'redirectURL') && $this->redirectURL) {
@@ -619,16 +607,16 @@ class OpenIDConnectClient
         } else {
             $protocol = @$_SERVER['HTTP_X_FORWARDED_PROTO']
                 ?: @$_SERVER['REQUEST_SCHEME']
-                ?: ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? 'https' : 'http');
+                    ?: ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? 'https' : 'http');
         }
 
         $port = @intval($_SERVER['HTTP_X_FORWARDED_PORT'])
             ?: @intval($_SERVER['SERVER_PORT'])
-            ?: (($protocol === 'https') ? 443 : 80);
+                ?: (($protocol === 'https') ? 443 : 80);
 
         $host = @explode(':', $_SERVER['HTTP_HOST'])[0]
             ?: @$_SERVER['SERVER_NAME']
-            ?: @$_SERVER['SERVER_ADDR'];
+                ?: @$_SERVER['SERVER_ADDR'];
 
         $port = (443 === $port) || (80 === $port) ? '' : ':' . $port;
 
@@ -641,8 +629,7 @@ class OpenIDConnectClient
      * @return string
      * @throws OpenIDConnectClientException
      */
-    protected function generateRandString()
-    {
+    protected function generateRandString() {
         // Error and Exception need to be catched in this order, see https://github.com/paragonie/random_compat/blob/master/README.md
         // random_compat polyfill library should be removed if support for PHP versions < 7 is dropped
         try {
@@ -659,8 +646,7 @@ class OpenIDConnectClient
      * @return void
      * @throws OpenIDConnectClientException
      */
-    private function requestAuthorization()
-    {
+    private function requestAuthorization() {
 
         $auth_endpoint = $this->getProviderConfigValue('authorization_endpoint');
         $response_type = 'code';
@@ -717,8 +703,7 @@ class OpenIDConnectClient
      *
      * @throws OpenIDConnectClientException
      */
-    public function requestClientCredentialsToken()
-    {
+    public function requestClientCredentialsToken() {
         $token_endpoint = $this->getProviderConfigValue('token_endpoint');
 
         $headers = [];
@@ -747,8 +732,7 @@ class OpenIDConnectClient
      * @return mixed
      * @throws OpenIDConnectClientException
      */
-    public function requestResourceOwnerToken($bClientAuth =  FALSE)
-    {
+    public function requestResourceOwnerToken($bClientAuth =  FALSE) {
         $token_endpoint = $this->getProviderConfigValue('token_endpoint');
 
         $headers = [];
@@ -763,7 +747,7 @@ class OpenIDConnectClient
         );
 
         //For client authentication include the client values
-        if ($bClientAuth) {
+        if($bClientAuth) {
             $post_data['client_id']     = $this->clientID;
             $post_data['client_secret'] = $this->clientSecret;
         }
@@ -782,8 +766,7 @@ class OpenIDConnectClient
      * @return mixed
      * @throws OpenIDConnectClientException
      */
-    protected function requestTokens($code)
-    {
+    protected function requestTokens($code) {
         $token_endpoint = $this->getProviderConfigValue('token_endpoint');
         $token_endpoint_auth_methods_supported = $this->getProviderConfigValue('token_endpoint_auth_methods_supported', ['client_secret_basic']);
 
@@ -803,7 +786,7 @@ class OpenIDConnectClient
         if (in_array('client_secret_basic', $token_endpoint_auth_methods_supported, true)) {
             $headers = ['Authorization: Basic ' . base64_encode(urlencode($this->clientID) . ':' . urlencode($this->clientSecret))];
             unset($token_params['client_secret']);
-            unset($token_params['client_id']);
+	        unset($token_params['client_id']);
         }
 
         if (!empty($this->getCodeChallengeMethod()) && !empty($this->getCodeVerifier())) {
@@ -830,8 +813,7 @@ class OpenIDConnectClient
      * @return mixed
      * @throws OpenIDConnectClientException
      */
-    public function refreshToken($refresh_token)
-    {
+    public function refreshToken($refresh_token) {
         $token_endpoint = $this->getProviderConfigValue('token_endpoint');
 
         $grant_type = 'refresh_token';
@@ -865,8 +847,7 @@ class OpenIDConnectClient
      * @throws OpenIDConnectClientException
      * @return object
      */
-    private function get_key_for_header($keys, $header)
-    {
+    private function get_key_for_header($keys, $header) {
         foreach ($keys as $key) {
             if ($key->kty === 'RSA') {
                 if (!isset($header->kid) || $key->kid === $header->kid) {
@@ -908,8 +889,7 @@ class OpenIDConnectClient
      * @return bool
      * @throws OpenIDConnectClientException
      */
-    private function verifyRSAJWTsignature($hashtype, $key, $payload, $signature, $signatureType)
-    {
+    private function verifyRSAJWTsignature($hashtype, $key, $payload, $signature, $signatureType) {
         if (!class_exists('\phpseclib\Crypt\RSA') && !class_exists('Crypt_RSA')) {
             throw new OpenIDConnectClientException('Crypt_RSA support unavailable.');
         }
@@ -920,11 +900,11 @@ class OpenIDConnectClient
         /* We already have base64url-encoded data, so re-encode it as
            regular base64 and use the XML key format for simplicity.
         */
-        $public_key_xml = "<RSAKeyValue>\r\n" .
+        $public_key_xml = "<RSAKeyValue>\r\n".
             '  <Modulus>' . b64url2b64($key->n) . "</Modulus>\r\n" .
             '  <Exponent>' . b64url2b64($key->e) . "</Exponent>\r\n" .
             '</RSAKeyValue>';
-        if (class_exists('Crypt_RSA', false)) {
+        if(class_exists('Crypt_RSA', false)) {
             $rsa = new Crypt_RSA();
             $rsa->setHash($hashtype);
             if ($signatureType === 'PSS') {
@@ -958,7 +938,7 @@ class OpenIDConnectClient
             throw new OpenIDConnectClientException('hash_hmac support unavailable.');
         }
 
-        $expected = hash_hmac($hashtype, $payload, $key, true);
+        $expected=hash_hmac($hashtype, $payload, $key, true);
 
         if (function_exists('hash_equals')) {
             return hash_equals($signature, $expected);
@@ -972,8 +952,7 @@ class OpenIDConnectClient
      * @throws OpenIDConnectClientException
      * @return bool
      */
-    public function verifyJWTsignature($jwt)
-    {
+    public function verifyJWTsignature($jwt) {
         if (!\is_string($jwt)) {
             throw new OpenIDConnectClientException('Error token is not a string');
         }
@@ -1005,13 +984,9 @@ class OpenIDConnectClient
                 $hashtype = 'sha' . substr($header->alg, 2);
                 $signatureType = $header->alg === 'PS256' ? 'PSS' : '';
 
-                $verified = $this->verifyRSAJWTsignature(
-                    $hashtype,
+                $verified = $this->verifyRSAJWTsignature($hashtype,
                     $this->get_key_for_header($jwks->keys, $header),
-                    $payload,
-                    $signature,
-                    $signatureType
-                );
+                    $payload, $signature, $signatureType);
                 break;
             case 'HS256':
             case 'HS512':
@@ -1030,24 +1005,23 @@ class OpenIDConnectClient
      * @param string|null $accessToken
      * @return bool
      */
-    protected function verifyJWTclaims($claims, $accessToken = null)
-    {
-        if (isset($claims->at_hash) && isset($accessToken)) {
-            if (isset($this->getIdTokenHeader()->alg) && $this->getIdTokenHeader()->alg !== 'none') {
+    protected function verifyJWTclaims($claims, $accessToken = null) {
+        if(isset($claims->at_hash) && isset($accessToken)){
+            if(isset($this->getIdTokenHeader()->alg) && $this->getIdTokenHeader()->alg !== 'none'){
                 $bit = substr($this->getIdTokenHeader()->alg, 2, 3);
-            } else {
+            }else{
                 // TODO: Error case. throw exception???
                 $bit = '256';
             }
-            $len = ((int)$bit) / 16;
-            $expected_at_hash = $this->urlEncode(substr(hash('sha' . $bit, $accessToken, true), 0, $len));
+            $len = ((int)$bit)/16;
+            $expected_at_hash = $this->urlEncode(substr(hash('sha'.$bit, $accessToken, true), 0, $len));
         }
         return (($this->issuerValidator->__invoke($claims->iss))
             && (($claims->aud === $this->clientID) || in_array($this->clientID, $claims->aud, true))
             && ($claims->nonce === $this->getNonce())
-            && (!isset($claims->exp) || ((gettype($claims->exp) === 'integer') && ($claims->exp >= time() - $this->leeway)))
-            && (!isset($claims->nbf) || ((gettype($claims->nbf) === 'integer') && ($claims->nbf <= time() + $this->leeway)))
-            && (!isset($claims->at_hash) || $claims->at_hash === $expected_at_hash)
+            && ( !isset($claims->exp) || ((gettype($claims->exp) === 'integer') && ($claims->exp >= time() - $this->leeway)))
+            && ( !isset($claims->nbf) || ((gettype($claims->nbf) === 'integer') && ($claims->nbf <= time() + $this->leeway)))
+            && ( !isset($claims->at_hash) || $claims->at_hash === $expected_at_hash )
         );
     }
 
@@ -1055,8 +1029,7 @@ class OpenIDConnectClient
      * @param string $str
      * @return string
      */
-    protected function urlEncode($str)
-    {
+    protected function urlEncode($str) {
         $enc = base64_encode($str);
         $enc = rtrim($enc, '=');
         $enc = strtr($enc, '+/', '-_');
@@ -1068,8 +1041,7 @@ class OpenIDConnectClient
      * @param int $section the section we would like to decode
      * @return object
      */
-    protected function decodeJWT($jwt, $section = 0)
-    {
+    protected function decodeJWT($jwt, $section = 0) {
 
         $parts = explode('.', $jwt);
         return json_decode(base64url_decode($parts[$section]));
@@ -1103,8 +1075,7 @@ class OpenIDConnectClient
      *
      * @throws OpenIDConnectClientException
      */
-    public function requestUserInfo($attribute = null)
-    {
+    public function requestUserInfo($attribute = null) {
 
         $user_info_endpoint = $this->getProviderConfigValue('userinfo_endpoint');
         $schema = 'openid';
@@ -1113,18 +1084,16 @@ class OpenIDConnectClient
 
         //The accessToken has to be sent in the Authorization header.
         // Accept json to indicate response type
-        $headers = [
-            "Authorization: Bearer {$this->accessToken}",
-            'Accept: application/json'
-        ];
+        $headers = ["Authorization: Bearer {$this->accessToken}",
+            'Accept: application/json'];
 
-        $user_json = json_decode($this->fetchURL($user_info_endpoint, null, $headers));
+        $user_json = json_decode($this->fetchURL($user_info_endpoint,null,$headers));
         if ($this->getResponseCode() <> 200) {
-            throw new OpenIDConnectClientException('The communication to retrieve user data has failed with status code ' . $this->getResponseCode());
+            throw new OpenIDConnectClientException('The communication to retrieve user data has failed with status code '.$this->getResponseCode());
         }
         $this->userInfo = $user_json;
 
-        if ($attribute === null) {
+        if($attribute === null) {
             return $this->userInfo;
         }
 
@@ -1154,10 +1123,9 @@ class OpenIDConnectClient
      * @return mixed
      *
      */
-    public function getVerifiedClaims($attribute = null)
-    {
+    public function getVerifiedClaims($attribute = null) {
 
-        if ($attribute === null) {
+        if($attribute === null) {
             return $this->verifiedClaims;
         }
 
@@ -1175,8 +1143,7 @@ class OpenIDConnectClient
      * @throws OpenIDConnectClientException
      * @return mixed
      */
-    protected function fetchURL($url, $post_body = null, $headers = array())
-    {
+    protected function fetchURL($url, $post_body = null, $headers = array()) {
 
 
         // OK cool - then let's create a new cURL resource handle
@@ -1199,10 +1166,11 @@ class OpenIDConnectClient
 
             // Add POST-specific headers
             $headers[] = "Content-Type: {$content_type}";
+
         }
 
         // If we set some headers include them
-        if (count($headers) > 0) {
+        if(count($headers) > 0) {
             curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         }
 
@@ -1227,13 +1195,13 @@ class OpenIDConnectClient
             curl_setopt($ch, CURLOPT_CAINFO, $this->certPath);
         }
 
-        if ($this->verifyHost) {
+        if($this->verifyHost) {
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
         } else {
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
         }
 
-        if ($this->verifyPeer) {
+        if($this->verifyPeer) {
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
         } else {
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
@@ -1267,8 +1235,7 @@ class OpenIDConnectClient
      * @return string
      * @throws OpenIDConnectClientException
      */
-    public function getWellKnownIssuer($appendSlash = false)
-    {
+    public function getWellKnownIssuer($appendSlash = false) {
 
         return $this->getWellKnownConfigValue('issuer') . ($appendSlash ? '/' : '');
     }
@@ -1277,8 +1244,7 @@ class OpenIDConnectClient
      * @return string
      * @throws OpenIDConnectClientException
      */
-    public function getIssuer()
-    {
+    public function getIssuer() {
 
         if (!isset($this->providerConfig['issuer'])) {
             throw new OpenIDConnectClientException('The issuer has not been set');
@@ -1291,8 +1257,7 @@ class OpenIDConnectClient
      * @return mixed
      * @throws OpenIDConnectClientException
      */
-    public function getProviderURL()
-    {
+    public function getProviderURL() {
         if (!isset($this->providerConfig['providerUrl'])) {
             throw new OpenIDConnectClientException('The provider URL has not been set');
         }
@@ -1303,8 +1268,7 @@ class OpenIDConnectClient
     /**
      * @param string $url
      */
-    public function redirect($url)
-    {
+    public function redirect($url) {
         header('Location: ' . $url);
         exit;
     }
@@ -1312,16 +1276,14 @@ class OpenIDConnectClient
     /**
      * @param string $httpProxy
      */
-    public function setHttpProxy($httpProxy)
-    {
+    public function setHttpProxy($httpProxy) {
         $this->httpProxy = $httpProxy;
     }
 
     /**
      * @param string $certPath
      */
-    public function setCertPath($certPath)
-    {
+    public function setCertPath($certPath) {
         $this->certPath = $certPath;
     }
 
@@ -1336,16 +1298,14 @@ class OpenIDConnectClient
     /**
      * @param bool $verifyPeer
      */
-    public function setVerifyPeer($verifyPeer)
-    {
+    public function setVerifyPeer($verifyPeer) {
         $this->verifyPeer = $verifyPeer;
     }
 
     /**
      * @param bool $verifyHost
      */
-    public function setVerifyHost($verifyHost)
-    {
+    public function setVerifyHost($verifyHost) {
         $this->verifyHost = $verifyHost;
     }
 
@@ -1372,16 +1332,14 @@ class OpenIDConnectClient
      *
      * @param callable $issuerValidator
      */
-    public function setIssuerValidator($issuerValidator)
-    {
+    public function setIssuerValidator($issuerValidator){
         $this->issuerValidator = $issuerValidator;
     }
 
     /**
      * @param bool $allowImplicitFlow
      */
-    public function setAllowImplicitFlow($allowImplicitFlow)
-    {
+    public function setAllowImplicitFlow($allowImplicitFlow) {
         $this->allowImplicitFlow = $allowImplicitFlow;
     }
 
@@ -1400,24 +1358,21 @@ class OpenIDConnectClient
      * @param array $array
      *        simple key => value
      */
-    public function providerConfigParam($array)
-    {
+    public function providerConfigParam($array) {
         $this->providerConfig = array_merge($this->providerConfig, $array);
     }
 
     /**
      * @param string $clientSecret
      */
-    public function setClientSecret($clientSecret)
-    {
+    public function setClientSecret($clientSecret) {
         $this->clientSecret = $clientSecret;
     }
 
     /**
      * @param string $clientID
      */
-    public function setClientID($clientID)
-    {
+    public function setClientID($clientID) {
         $this->clientID = $clientID;
     }
 
@@ -1427,12 +1382,11 @@ class OpenIDConnectClient
      *
      * @throws OpenIDConnectClientException
      */
-    public function register()
-    {
+    public function register() {
 
         $registration_endpoint = $this->getProviderConfigValue('registration_endpoint');
 
-        $send_object = (object) array_merge($this->registrationParams, array(
+        $send_object = (object ) array_merge($this->registrationParams, array(
             'redirect_uris' => array($this->getRedirectURL()),
             'client_name' => $this->getClientName()
         ));
@@ -1460,6 +1414,7 @@ class OpenIDConnectClient
             throw new OpenIDConnectClientException('Error registering:
                                                     Please contact the OpenID Connect provider and obtain a Client ID and Secret directly from them');
         }
+
     }
 
     /**
@@ -1473,8 +1428,7 @@ class OpenIDConnectClient
      * @return mixed
      * @throws OpenIDConnectClientException
      */
-    public function introspectToken($token, $token_type_hint = '', $clientId = null, $clientSecret = null)
-    {
+    public function introspectToken($token, $token_type_hint = '', $clientId = null, $clientSecret = null) {
         $introspection_endpoint = $this->getProviderConfigValue('introspection_endpoint');
 
         $post_data = array(
@@ -1488,10 +1442,8 @@ class OpenIDConnectClient
 
         // Convert token params to string format
         $post_params = http_build_query($post_data, '', '&');
-        $headers = [
-            'Authorization: Basic ' . base64_encode(urlencode($clientId) . ':' . urlencode($clientSecret)),
-            'Accept: application/json'
-        ];
+        $headers = ['Authorization: Basic ' . base64_encode(urlencode($clientId) . ':' . urlencode($clientSecret)),
+            'Accept: application/json'];
 
         return json_decode($this->fetchURL($introspection_endpoint, $post_params, $headers));
     }
@@ -1507,8 +1459,7 @@ class OpenIDConnectClient
      * @return mixed
      * @throws OpenIDConnectClientException
      */
-    public function revokeToken($token, $token_type_hint = '', $clientId = null, $clientSecret = null)
-    {
+    public function revokeToken($token, $token_type_hint = '', $clientId = null, $clientSecret = null) {
         $revocation_endpoint = $this->getProviderConfigValue('revocation_endpoint');
 
         $post_data = array(
@@ -1522,10 +1473,8 @@ class OpenIDConnectClient
 
         // Convert token params to string format
         $post_params = http_build_query($post_data, '', '&');
-        $headers = [
-            'Authorization: Basic ' . base64_encode(urlencode($clientId) . ':' . urlencode($clientSecret)),
-            'Accept: application/json'
-        ];
+        $headers = ['Authorization: Basic ' . base64_encode(urlencode($clientId) . ':' . urlencode($clientSecret)),
+            'Accept: application/json'];
 
         return json_decode($this->fetchURL($revocation_endpoint, $post_params, $headers));
     }
@@ -1533,40 +1482,35 @@ class OpenIDConnectClient
     /**
      * @return string
      */
-    public function getClientName()
-    {
+    public function getClientName() {
         return $this->clientName;
     }
 
     /**
      * @param string $clientName
      */
-    public function setClientName($clientName)
-    {
+    public function setClientName($clientName) {
         $this->clientName = $clientName;
     }
 
     /**
      * @return string
      */
-    public function getClientID()
-    {
+    public function getClientID() {
         return $this->clientID;
     }
 
     /**
      * @return string
      */
-    public function getClientSecret()
-    {
+    public function getClientSecret() {
         return $this->clientSecret;
     }
 
     /**
      * @return bool
      */
-    public function canVerifySignatures()
-    {
+    public function canVerifySignatures() {
         return class_exists('\phpseclib\Crypt\RSA') || class_exists('Crypt_RSA');
     }
 
@@ -1578,72 +1522,63 @@ class OpenIDConnectClient
      * @param string $accessToken
      * @return void
      */
-    public function setAccessToken($accessToken)
-    {
+    public function setAccessToken($accessToken) {
         $this->accessToken = $accessToken;
     }
 
     /**
      * @return string
      */
-    public function getAccessToken()
-    {
+    public function getAccessToken() {
         return $this->accessToken;
     }
 
     /**
      * @return string
      */
-    public function getRefreshToken()
-    {
+    public function getRefreshToken() {
         return $this->refreshToken;
     }
 
     /**
      * @return string
      */
-    public function getIdToken()
-    {
+    public function getIdToken() {
         return $this->idToken;
     }
 
     /**
      * @return object
      */
-    public function getAccessTokenHeader()
-    {
+    public function getAccessTokenHeader() {
         return $this->decodeJWT($this->accessToken);
     }
 
     /**
      * @return object
      */
-    public function getAccessTokenPayload()
-    {
+    public function getAccessTokenPayload() {
         return $this->decodeJWT($this->accessToken, 1);
     }
 
     /**
      * @return object
      */
-    public function getIdTokenHeader()
-    {
+    public function getIdTokenHeader() {
         return $this->decodeJWT($this->idToken);
     }
 
     /**
      * @return object
      */
-    public function getIdTokenPayload()
-    {
+    public function getIdTokenPayload() {
         return $this->decodeJWT($this->idToken, 1);
     }
 
     /**
      * @return string
      */
-    public function getTokenResponse()
-    {
+    public function getTokenResponse() {
         return $this->tokenResponse;
     }
 
@@ -1653,8 +1588,7 @@ class OpenIDConnectClient
      * @param string $nonce
      * @return string
      */
-    protected function setNonce($nonce)
-    {
+    protected function setNonce($nonce) {
         $this->setSessionKey('openid_connect_nonce', $nonce);
         return $nonce;
     }
@@ -1664,8 +1598,7 @@ class OpenIDConnectClient
      *
      * @return string
      */
-    protected function getNonce()
-    {
+    protected function getNonce() {
         return $this->getSessionKey('openid_connect_nonce');
     }
 
@@ -1674,8 +1607,7 @@ class OpenIDConnectClient
      *
      * @return void
      */
-    protected function unsetNonce()
-    {
+    protected function unsetNonce() {
         $this->unsetSessionKey('openid_connect_nonce');
     }
 
@@ -1685,8 +1617,7 @@ class OpenIDConnectClient
      * @param string $state
      * @return string
      */
-    protected function setState($state)
-    {
+    protected function setState($state) {
         $this->setSessionKey('openid_connect_state', $state);
         return $state;
     }
@@ -1696,8 +1627,7 @@ class OpenIDConnectClient
      *
      * @return string
      */
-    protected function getState()
-    {
+    protected function getState() {
         return $this->getSessionKey('openid_connect_state');
     }
 
@@ -1706,8 +1636,7 @@ class OpenIDConnectClient
      *
      * @return void
      */
-    protected function unsetState()
-    {
+    protected function unsetState() {
         $this->unsetSessionKey('openid_connect_state');
     }
 
@@ -1717,8 +1646,7 @@ class OpenIDConnectClient
      * @param string $codeVerifier
      * @return string
      */
-    protected function setCodeVerifier($codeVerifier)
-    {
+    protected function setCodeVerifier($codeVerifier) {
         $this->setSessionKey('openid_connect_code_verifier', $codeVerifier);
         return $codeVerifier;
     }
@@ -1728,8 +1656,7 @@ class OpenIDConnectClient
      *
      * @return string
      */
-    protected function getCodeVerifier()
-    {
+    protected function getCodeVerifier() {
         return $this->getSessionKey('openid_connect_code_verifier');
     }
 
@@ -1738,8 +1665,7 @@ class OpenIDConnectClient
      *
      * @return void
      */
-    protected function unsetCodeVerifier()
-    {
+    protected function unsetCodeVerifier() {
         $this->unsetSessionKey('openid_connect_code_verifier');
     }
 
@@ -1792,8 +1718,8 @@ class OpenIDConnectClient
      */
     private static function hashEquals($str1, $str2)
     {
-        $len1 = static::safeLength($str1);
-        $len2 = static::safeLength($str2);
+        $len1=static::safeLength($str1);
+        $len2=static::safeLength($str2);
 
         //compare strings without any early abort...
         $len = min($len1, $len2);
@@ -1809,36 +1735,31 @@ class OpenIDConnectClient
     /**
      * Use session to manage a nonce
      */
-    protected function startSession()
-    {
+    protected function startSession() {
         if (!isset($_SESSION)) {
             @session_start();
         }
     }
 
-    protected function commitSession()
-    {
+    protected function commitSession() {
         $this->startSession();
 
         session_write_close();
     }
 
-    protected function getSessionKey($key)
-    {
+    protected function getSessionKey($key) {
         $this->startSession();
 
         return $_SESSION[$key];
     }
 
-    protected function setSessionKey($key, $value)
-    {
+    protected function setSessionKey($key, $value) {
         $this->startSession();
 
         $_SESSION[$key] = $value;
     }
 
-    protected function unsetSessionKey($key)
-    {
+    protected function unsetSessionKey($key) {
         $this->startSession();
 
         unset($_SESSION[$key]);
@@ -1846,7 +1767,8 @@ class OpenIDConnectClient
 
     public function setUrlEncoding($curEncoding)
     {
-        switch ($curEncoding) {
+        switch ($curEncoding)
+        {
             case PHP_QUERY_RFC1738:
                 $this->enc_type = PHP_QUERY_RFC1738;
                 break;
@@ -1855,9 +1777,10 @@ class OpenIDConnectClient
                 $this->enc_type = PHP_QUERY_RFC3986;
                 break;
 
-            default:
+        	default:
                 break;
         }
+
     }
 
     /**
@@ -1903,16 +1826,14 @@ class OpenIDConnectClient
     /**
      * @return string
      */
-    public function getCodeChallengeMethod()
-    {
+    public function getCodeChallengeMethod() {
         return $this->codeChallengeMethod;
     }
 
     /**
      * @param string $codeChallengeMethod
      */
-    public function setCodeChallengeMethod($codeChallengeMethod)
-    {
+    public function setCodeChallengeMethod($codeChallengeMethod) {
         $this->codeChallengeMethod = $codeChallengeMethod;
     }
 }

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  *
  * Copyright MITRE 2020
@@ -41,7 +42,8 @@ if (!class_exists('\phpseclib\Crypt\RSA') && !class_exists('Crypt_RSA')) {
  * @param string $base64url
  * @return bool|string
  */
-function base64url_decode($base64url) {
+function base64url_decode($base64url)
+{
     return base64_decode(b64url2b64($base64url));
 }
 
@@ -53,7 +55,8 @@ function base64url_decode($base64url) {
  * @param string $base64url
  * @return string
  */
-function b64url2b64($base64url) {
+function b64url2b64($base64url)
+{
     // "Shouldn't" be necessary, but why not
     $padding = strlen($base64url) % 4;
     if ($padding > 0) {
@@ -66,10 +69,7 @@ function b64url2b64($base64url) {
 /**
  * OpenIDConnect Exception Class
  */
-class OpenIDConnectClientException extends \Exception
-{
-
-}
+class OpenIDConnectClientException extends \Exception {}
 
 /**
  * Require the CURL and JSON PHP extensions to be installed
@@ -244,7 +244,8 @@ class OpenIDConnectClient
      * @param $client_secret string optional
      * @param null $issuer
      */
-    public function __construct($provider_url = null, $client_id = null, $client_secret = null, $issuer = null) {
+    public function __construct($provider_url = null, $client_id = null, $client_secret = null, $issuer = null)
+    {
         $this->setProviderURL($provider_url);
         if ($issuer === null) {
             $this->setIssuer($provider_url);
@@ -255,29 +256,32 @@ class OpenIDConnectClient
         $this->clientID = $client_id;
         $this->clientSecret = $client_secret;
 
-        $this->issuerValidator = function($iss){
-	        return ($iss === $this->getIssuer() || $iss === $this->getWellKnownIssuer() || $iss === $this->getWellKnownIssuer(true));
+        $this->issuerValidator = function ($iss) {
+            return ($iss === $this->getIssuer() || $iss === $this->getWellKnownIssuer() || $iss === $this->getWellKnownIssuer(true));
         };
     }
 
     /**
      * @param $provider_url
      */
-    public function setProviderURL($provider_url) {
+    public function setProviderURL($provider_url)
+    {
         $this->providerConfig['providerUrl'] = $provider_url;
     }
 
     /**
      * @param $issuer
      */
-    public function setIssuer($issuer) {
+    public function setIssuer($issuer)
+    {
         $this->providerConfig['issuer'] = $issuer;
     }
 
     /**
      * @param $response_types
      */
-    public function setResponseTypes($response_types) {
+    public function setResponseTypes($response_types)
+    {
         $this->responseTypes = array_merge($this->responseTypes, (array)$response_types);
     }
 
@@ -285,12 +289,13 @@ class OpenIDConnectClient
      * @return bool
      * @throws OpenIDConnectClientException
      */
-    public function authenticate() {
+    public function authenticate()
+    {
 
         // Do a preemptive check to see if the provider has thrown an error from a previous redirect
         if (isset($_REQUEST['error'])) {
             $desc = isset($_REQUEST['error_description']) ? ' Description: ' . $_REQUEST['error_description'] : '';
-            throw new OpenIDConnectClientException('Error: ' . $_REQUEST['error'] .$desc);
+            throw new OpenIDConnectClientException('Error: ' . $_REQUEST['error'] . $desc);
         }
 
         // If we have an authorization code then proceed to request a token
@@ -311,7 +316,7 @@ class OpenIDConnectClient
             // and the authentication process fail
             if ($this->getState() == "")
                 $this->setState($_REQUEST['state']);
-            
+
             // Do an OpenID Connect session check
             if ($_REQUEST['state'] !== $this->getState()) {
                 throw new OpenIDConnectClientException('Unable to determine state');
@@ -329,10 +334,10 @@ class OpenIDConnectClient
             // Verify the signature
             if ($this->canVerifySignatures()) {
                 if (!$this->getProviderConfigValue('jwks_uri')) {
-                    throw new OpenIDConnectClientException ('Unable to verify signature due to no jwks_uri being defined');
+                    throw new OpenIDConnectClientException('Unable to verify signature due to no jwks_uri being defined');
                 }
                 if (!$this->verifyJWTsignature($token_json->id_token)) {
-                    throw new OpenIDConnectClientException ('Unable to verify signature');
+                    throw new OpenIDConnectClientException('Unable to verify signature');
                 }
             } else {
                 user_error('Warning: JWT signature verification unavailable.');
@@ -350,7 +355,7 @@ class OpenIDConnectClient
                 $this->setNonce($claims->nonce);
                 user_error('Warning: Function getNonce return empty, setting in the session!');
             };
-            
+
             // If this is a valid claim
             if ($this->verifyJWTclaims($claims, $token_json->access_token)) {
 
@@ -370,10 +375,9 @@ class OpenIDConnectClient
 
                 // Success!
                 return true;
-
             }
 
-            throw new OpenIDConnectClientException ('Unable to verify JWT claims');
+            throw new OpenIDConnectClientException('Unable to verify JWT claims');
         }
 
         if ($this->allowImplicitFlow && isset($_REQUEST['id_token'])) {
@@ -398,10 +402,10 @@ class OpenIDConnectClient
             // Verify the signature
             if ($this->canVerifySignatures()) {
                 if (!$this->getProviderConfigValue('jwks_uri')) {
-                    throw new OpenIDConnectClientException ('Unable to verify signature due to no jwks_uri being defined');
+                    throw new OpenIDConnectClientException('Unable to verify signature due to no jwks_uri being defined');
                 }
                 if (!$this->verifyJWTsignature($id_token)) {
-                    throw new OpenIDConnectClientException ('Unable to verify signature');
+                    throw new OpenIDConnectClientException('Unable to verify signature');
                 }
             } else {
                 user_error('Warning: JWT signature verification unavailable.');
@@ -426,15 +430,13 @@ class OpenIDConnectClient
 
                 // Success!
                 return true;
-
             }
 
-            throw new OpenIDConnectClientException ('Unable to verify JWT claims');
+            throw new OpenIDConnectClientException('Unable to verify JWT claims');
         }
 
         $this->requestAuthorization();
         return false;
-
     }
 
     /**
@@ -451,51 +453,56 @@ class OpenIDConnectClient
      *
      * @throws OpenIDConnectClientException
      */
-    public function signOut($enduserIdentification, $redirect, $method = "id_token_hint") {
-        if (!in_array($method, array("id_token_hint", "login_hint")))
-            throw new OpenIDConnectClientException('method must be "id_token_hint" or "login_hint"');
+    public function signOut($enduserIdentification, $redirect, $method = "id_token_hint")
+    {
+        if (!in_array($method, array("id_token_hint", "login_hint", "client_id")))
+            throw new OpenIDConnectClientException('method must be "id_token_hint" or "login_hint" or "client_id"');
 
         $signout_endpoint = $this->getProviderConfigValue("end_session_endpoint");
 
         $signout_params = null;
-        if($redirect === null){
+        if ($redirect === null) {
             $signout_params = array($method => $enduserIdentification);
-        }
-        else {
+        } else {
             $signout_params = array(
                 $method => $enduserIdentification,
-                'post_logout_redirect_uri' => $redirect);
+                'post_logout_redirect_uri' => $redirect,
+            );
         }
 
-        $signout_endpoint  .= (strpos($signout_endpoint, '?') === false ? '?' : '&') . http_build_query( $signout_params, '', '&', $this->enc_type);
+        $signout_endpoint  .= (strpos($signout_endpoint, '?') === false ? '?' : '&') . http_build_query($signout_params, '', '&', $this->enc_type);
         $this->redirect($signout_endpoint);
     }
 
     /**
      * @param array $scope - example: openid, given_name, etc...
      */
-    public function addScope($scope) {
+    public function addScope($scope)
+    {
         $this->scopes = array_merge($this->scopes, (array)$scope);
     }
 
     /**
      * @param array $param - example: prompt=login
      */
-    public function addAuthParam($param) {
+    public function addAuthParam($param)
+    {
         $this->authParams = array_merge($this->authParams, (array)$param);
     }
 
     /**
      * @param array $param - example: post_logout_redirect_uris=[http://example.com/successful-logout]
      */
-    public function addRegistrationParam($param) {
+    public function addRegistrationParam($param)
+    {
         $this->registrationParams = array_merge($this->registrationParams, (array)$param);
     }
 
     /**
      * @param $jwk object - example: (object) array('kid' => ..., 'nbf' => ..., 'use' => 'sig', 'kty' => "RSA", 'e' => "", 'n' => "")
      */
-    protected function addAdditionalJwk($jwk) {
+    protected function addAdditionalJwk($jwk)
+    {
         $this->additionalJwks[] = $jwk;
     }
 
@@ -508,7 +515,8 @@ class OpenIDConnectClient
      * @return string
      *
      */
-    protected function getProviderConfigValue($param, $default = null) {
+    protected function getProviderConfigValue($param, $default = null)
+    {
 
         // If the configuration value is not available, attempt to fetch it from a well known config endpoint
         // This is also known as auto "discovery"
@@ -528,20 +536,21 @@ class OpenIDConnectClient
      * @return string
      *
      */
-    private function getWellKnownConfigValue($param, $default = null) {
+    private function getWellKnownConfigValue($param, $default = null)
+    {
 
         // If the configuration value is not available, attempt to fetch it from a well known config endpoint
         // This is also known as auto "discovery"
-        if(!$this->wellKnown) {
+        if (!$this->wellKnown) {
             $well_known_config_url = rtrim($this->getProviderURL(), '/') . '/.well-known/openid-configuration';
-            if (count($this->wellKnownConfigParameters) > 0){
-                $well_known_config_url .= '?' .  http_build_query($this->wellKnownConfigParameters) ;
+            if (count($this->wellKnownConfigParameters) > 0) {
+                $well_known_config_url .= '?' .  http_build_query($this->wellKnownConfigParameters);
             }
             $this->wellKnown = json_decode($this->fetchURL($well_known_config_url));
         }
 
         $value = false;
-        if(isset($this->wellKnown->{$param})){
+        if (isset($this->wellKnown->{$param})) {
             $value = $this->wellKnown->{$param};
         }
 
@@ -563,16 +572,18 @@ class OpenIDConnectClient
      * @param string $param
      *
      */
-    public function setWellKnownConfigParameters(array $params = []){
-        $this->wellKnownConfigParameters=$params;
+    public function setWellKnownConfigParameters(array $params = [])
+    {
+        $this->wellKnownConfigParameters = $params;
     }
 
 
     /**
      * @param string $url Sets redirect URL for auth flow
      */
-    public function setRedirectURL ($url) {
-        if (parse_url($url,PHP_URL_HOST) !== false) {
+    public function setRedirectURL($url)
+    {
+        if (parse_url($url, PHP_URL_HOST) !== false) {
             $this->redirectURL = $url;
         }
     }
@@ -582,7 +593,8 @@ class OpenIDConnectClient
      *
      * @return string
      */
-    public function getRedirectURL() {
+    public function getRedirectURL()
+    {
 
         // If the redirect URL has been set then return it.
         if (property_exists($this, 'redirectURL') && $this->redirectURL) {
@@ -607,16 +619,16 @@ class OpenIDConnectClient
         } else {
             $protocol = @$_SERVER['HTTP_X_FORWARDED_PROTO']
                 ?: @$_SERVER['REQUEST_SCHEME']
-                    ?: ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? 'https' : 'http');
+                ?: ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? 'https' : 'http');
         }
 
         $port = @intval($_SERVER['HTTP_X_FORWARDED_PORT'])
             ?: @intval($_SERVER['SERVER_PORT'])
-                ?: (($protocol === 'https') ? 443 : 80);
+            ?: (($protocol === 'https') ? 443 : 80);
 
         $host = @explode(':', $_SERVER['HTTP_HOST'])[0]
             ?: @$_SERVER['SERVER_NAME']
-                ?: @$_SERVER['SERVER_ADDR'];
+            ?: @$_SERVER['SERVER_ADDR'];
 
         $port = (443 === $port) || (80 === $port) ? '' : ':' . $port;
 
@@ -629,7 +641,8 @@ class OpenIDConnectClient
      * @return string
      * @throws OpenIDConnectClientException
      */
-    protected function generateRandString() {
+    protected function generateRandString()
+    {
         // Error and Exception need to be catched in this order, see https://github.com/paragonie/random_compat/blob/master/README.md
         // random_compat polyfill library should be removed if support for PHP versions < 7 is dropped
         try {
@@ -646,7 +659,8 @@ class OpenIDConnectClient
      * @return void
      * @throws OpenIDConnectClientException
      */
-    private function requestAuthorization() {
+    private function requestAuthorization()
+    {
 
         $auth_endpoint = $this->getProviderConfigValue('authorization_endpoint');
         $response_type = 'code';
@@ -703,7 +717,8 @@ class OpenIDConnectClient
      *
      * @throws OpenIDConnectClientException
      */
-    public function requestClientCredentialsToken() {
+    public function requestClientCredentialsToken()
+    {
         $token_endpoint = $this->getProviderConfigValue('token_endpoint');
 
         $headers = [];
@@ -732,7 +747,8 @@ class OpenIDConnectClient
      * @return mixed
      * @throws OpenIDConnectClientException
      */
-    public function requestResourceOwnerToken($bClientAuth =  FALSE) {
+    public function requestResourceOwnerToken($bClientAuth =  FALSE)
+    {
         $token_endpoint = $this->getProviderConfigValue('token_endpoint');
 
         $headers = [];
@@ -747,7 +763,7 @@ class OpenIDConnectClient
         );
 
         //For client authentication include the client values
-        if($bClientAuth) {
+        if ($bClientAuth) {
             $post_data['client_id']     = $this->clientID;
             $post_data['client_secret'] = $this->clientSecret;
         }
@@ -766,7 +782,8 @@ class OpenIDConnectClient
      * @return mixed
      * @throws OpenIDConnectClientException
      */
-    protected function requestTokens($code) {
+    protected function requestTokens($code)
+    {
         $token_endpoint = $this->getProviderConfigValue('token_endpoint');
         $token_endpoint_auth_methods_supported = $this->getProviderConfigValue('token_endpoint_auth_methods_supported', ['client_secret_basic']);
 
@@ -786,7 +803,7 @@ class OpenIDConnectClient
         if (in_array('client_secret_basic', $token_endpoint_auth_methods_supported, true)) {
             $headers = ['Authorization: Basic ' . base64_encode(urlencode($this->clientID) . ':' . urlencode($this->clientSecret))];
             unset($token_params['client_secret']);
-	        unset($token_params['client_id']);
+            unset($token_params['client_id']);
         }
 
         if (!empty($this->getCodeChallengeMethod()) && !empty($this->getCodeVerifier())) {
@@ -813,7 +830,8 @@ class OpenIDConnectClient
      * @return mixed
      * @throws OpenIDConnectClientException
      */
-    public function refreshToken($refresh_token) {
+    public function refreshToken($refresh_token)
+    {
         $token_endpoint = $this->getProviderConfigValue('token_endpoint');
 
         $grant_type = 'refresh_token';
@@ -847,7 +865,8 @@ class OpenIDConnectClient
      * @throws OpenIDConnectClientException
      * @return object
      */
-    private function get_key_for_header($keys, $header) {
+    private function get_key_for_header($keys, $header)
+    {
         foreach ($keys as $key) {
             if ($key->kty === 'RSA') {
                 if (!isset($header->kid) || $key->kid === $header->kid) {
@@ -889,7 +908,8 @@ class OpenIDConnectClient
      * @return bool
      * @throws OpenIDConnectClientException
      */
-    private function verifyRSAJWTsignature($hashtype, $key, $payload, $signature, $signatureType) {
+    private function verifyRSAJWTsignature($hashtype, $key, $payload, $signature, $signatureType)
+    {
         if (!class_exists('\phpseclib\Crypt\RSA') && !class_exists('Crypt_RSA')) {
             throw new OpenIDConnectClientException('Crypt_RSA support unavailable.');
         }
@@ -900,11 +920,11 @@ class OpenIDConnectClient
         /* We already have base64url-encoded data, so re-encode it as
            regular base64 and use the XML key format for simplicity.
         */
-        $public_key_xml = "<RSAKeyValue>\r\n".
+        $public_key_xml = "<RSAKeyValue>\r\n" .
             '  <Modulus>' . b64url2b64($key->n) . "</Modulus>\r\n" .
             '  <Exponent>' . b64url2b64($key->e) . "</Exponent>\r\n" .
             '</RSAKeyValue>';
-        if(class_exists('Crypt_RSA', false)) {
+        if (class_exists('Crypt_RSA', false)) {
             $rsa = new Crypt_RSA();
             $rsa->setHash($hashtype);
             if ($signatureType === 'PSS') {
@@ -938,7 +958,7 @@ class OpenIDConnectClient
             throw new OpenIDConnectClientException('hash_hmac support unavailable.');
         }
 
-        $expected=hash_hmac($hashtype, $payload, $key, true);
+        $expected = hash_hmac($hashtype, $payload, $key, true);
 
         if (function_exists('hash_equals')) {
             return hash_equals($signature, $expected);
@@ -952,7 +972,8 @@ class OpenIDConnectClient
      * @throws OpenIDConnectClientException
      * @return bool
      */
-    public function verifyJWTsignature($jwt) {
+    public function verifyJWTsignature($jwt)
+    {
         if (!\is_string($jwt)) {
             throw new OpenIDConnectClientException('Error token is not a string');
         }
@@ -984,9 +1005,13 @@ class OpenIDConnectClient
                 $hashtype = 'sha' . substr($header->alg, 2);
                 $signatureType = $header->alg === 'PS256' ? 'PSS' : '';
 
-                $verified = $this->verifyRSAJWTsignature($hashtype,
+                $verified = $this->verifyRSAJWTsignature(
+                    $hashtype,
                     $this->get_key_for_header($jwks->keys, $header),
-                    $payload, $signature, $signatureType);
+                    $payload,
+                    $signature,
+                    $signatureType
+                );
                 break;
             case 'HS256':
             case 'HS512':
@@ -1005,23 +1030,24 @@ class OpenIDConnectClient
      * @param string|null $accessToken
      * @return bool
      */
-    protected function verifyJWTclaims($claims, $accessToken = null) {
-        if(isset($claims->at_hash) && isset($accessToken)){
-            if(isset($this->getIdTokenHeader()->alg) && $this->getIdTokenHeader()->alg !== 'none'){
+    protected function verifyJWTclaims($claims, $accessToken = null)
+    {
+        if (isset($claims->at_hash) && isset($accessToken)) {
+            if (isset($this->getIdTokenHeader()->alg) && $this->getIdTokenHeader()->alg !== 'none') {
                 $bit = substr($this->getIdTokenHeader()->alg, 2, 3);
-            }else{
+            } else {
                 // TODO: Error case. throw exception???
                 $bit = '256';
             }
-            $len = ((int)$bit)/16;
-            $expected_at_hash = $this->urlEncode(substr(hash('sha'.$bit, $accessToken, true), 0, $len));
+            $len = ((int)$bit) / 16;
+            $expected_at_hash = $this->urlEncode(substr(hash('sha' . $bit, $accessToken, true), 0, $len));
         }
         return (($this->issuerValidator->__invoke($claims->iss))
             && (($claims->aud === $this->clientID) || in_array($this->clientID, $claims->aud, true))
             && ($claims->nonce === $this->getNonce())
-            && ( !isset($claims->exp) || ((gettype($claims->exp) === 'integer') && ($claims->exp >= time() - $this->leeway)))
-            && ( !isset($claims->nbf) || ((gettype($claims->nbf) === 'integer') && ($claims->nbf <= time() + $this->leeway)))
-            && ( !isset($claims->at_hash) || $claims->at_hash === $expected_at_hash )
+            && (!isset($claims->exp) || ((gettype($claims->exp) === 'integer') && ($claims->exp >= time() - $this->leeway)))
+            && (!isset($claims->nbf) || ((gettype($claims->nbf) === 'integer') && ($claims->nbf <= time() + $this->leeway)))
+            && (!isset($claims->at_hash) || $claims->at_hash === $expected_at_hash)
         );
     }
 
@@ -1029,7 +1055,8 @@ class OpenIDConnectClient
      * @param string $str
      * @return string
      */
-    protected function urlEncode($str) {
+    protected function urlEncode($str)
+    {
         $enc = base64_encode($str);
         $enc = rtrim($enc, '=');
         $enc = strtr($enc, '+/', '-_');
@@ -1041,7 +1068,8 @@ class OpenIDConnectClient
      * @param int $section the section we would like to decode
      * @return object
      */
-    protected function decodeJWT($jwt, $section = 0) {
+    protected function decodeJWT($jwt, $section = 0)
+    {
 
         $parts = explode('.', $jwt);
         return json_decode(base64url_decode($parts[$section]));
@@ -1075,7 +1103,8 @@ class OpenIDConnectClient
      *
      * @throws OpenIDConnectClientException
      */
-    public function requestUserInfo($attribute = null) {
+    public function requestUserInfo($attribute = null)
+    {
 
         $user_info_endpoint = $this->getProviderConfigValue('userinfo_endpoint');
         $schema = 'openid';
@@ -1084,16 +1113,18 @@ class OpenIDConnectClient
 
         //The accessToken has to be sent in the Authorization header.
         // Accept json to indicate response type
-        $headers = ["Authorization: Bearer {$this->accessToken}",
-            'Accept: application/json'];
+        $headers = [
+            "Authorization: Bearer {$this->accessToken}",
+            'Accept: application/json'
+        ];
 
-        $user_json = json_decode($this->fetchURL($user_info_endpoint,null,$headers));
+        $user_json = json_decode($this->fetchURL($user_info_endpoint, null, $headers));
         if ($this->getResponseCode() <> 200) {
-            throw new OpenIDConnectClientException('The communication to retrieve user data has failed with status code '.$this->getResponseCode());
+            throw new OpenIDConnectClientException('The communication to retrieve user data has failed with status code ' . $this->getResponseCode());
         }
         $this->userInfo = $user_json;
 
-        if($attribute === null) {
+        if ($attribute === null) {
             return $this->userInfo;
         }
 
@@ -1123,9 +1154,10 @@ class OpenIDConnectClient
      * @return mixed
      *
      */
-    public function getVerifiedClaims($attribute = null) {
+    public function getVerifiedClaims($attribute = null)
+    {
 
-        if($attribute === null) {
+        if ($attribute === null) {
             return $this->verifiedClaims;
         }
 
@@ -1143,7 +1175,8 @@ class OpenIDConnectClient
      * @throws OpenIDConnectClientException
      * @return mixed
      */
-    protected function fetchURL($url, $post_body = null, $headers = array()) {
+    protected function fetchURL($url, $post_body = null, $headers = array())
+    {
 
 
         // OK cool - then let's create a new cURL resource handle
@@ -1166,11 +1199,10 @@ class OpenIDConnectClient
 
             // Add POST-specific headers
             $headers[] = "Content-Type: {$content_type}";
-
         }
 
         // If we set some headers include them
-        if(count($headers) > 0) {
+        if (count($headers) > 0) {
             curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         }
 
@@ -1195,13 +1227,13 @@ class OpenIDConnectClient
             curl_setopt($ch, CURLOPT_CAINFO, $this->certPath);
         }
 
-        if($this->verifyHost) {
+        if ($this->verifyHost) {
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
         } else {
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
         }
 
-        if($this->verifyPeer) {
+        if ($this->verifyPeer) {
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
         } else {
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
@@ -1235,7 +1267,8 @@ class OpenIDConnectClient
      * @return string
      * @throws OpenIDConnectClientException
      */
-    public function getWellKnownIssuer($appendSlash = false) {
+    public function getWellKnownIssuer($appendSlash = false)
+    {
 
         return $this->getWellKnownConfigValue('issuer') . ($appendSlash ? '/' : '');
     }
@@ -1244,7 +1277,8 @@ class OpenIDConnectClient
      * @return string
      * @throws OpenIDConnectClientException
      */
-    public function getIssuer() {
+    public function getIssuer()
+    {
 
         if (!isset($this->providerConfig['issuer'])) {
             throw new OpenIDConnectClientException('The issuer has not been set');
@@ -1257,7 +1291,8 @@ class OpenIDConnectClient
      * @return mixed
      * @throws OpenIDConnectClientException
      */
-    public function getProviderURL() {
+    public function getProviderURL()
+    {
         if (!isset($this->providerConfig['providerUrl'])) {
             throw new OpenIDConnectClientException('The provider URL has not been set');
         }
@@ -1268,7 +1303,8 @@ class OpenIDConnectClient
     /**
      * @param string $url
      */
-    public function redirect($url) {
+    public function redirect($url)
+    {
         header('Location: ' . $url);
         exit;
     }
@@ -1276,14 +1312,16 @@ class OpenIDConnectClient
     /**
      * @param string $httpProxy
      */
-    public function setHttpProxy($httpProxy) {
+    public function setHttpProxy($httpProxy)
+    {
         $this->httpProxy = $httpProxy;
     }
 
     /**
      * @param string $certPath
      */
-    public function setCertPath($certPath) {
+    public function setCertPath($certPath)
+    {
         $this->certPath = $certPath;
     }
 
@@ -1298,14 +1336,16 @@ class OpenIDConnectClient
     /**
      * @param bool $verifyPeer
      */
-    public function setVerifyPeer($verifyPeer) {
+    public function setVerifyPeer($verifyPeer)
+    {
         $this->verifyPeer = $verifyPeer;
     }
 
     /**
      * @param bool $verifyHost
      */
-    public function setVerifyHost($verifyHost) {
+    public function setVerifyHost($verifyHost)
+    {
         $this->verifyHost = $verifyHost;
     }
 
@@ -1332,14 +1372,16 @@ class OpenIDConnectClient
      *
      * @param callable $issuerValidator
      */
-    public function setIssuerValidator($issuerValidator){
+    public function setIssuerValidator($issuerValidator)
+    {
         $this->issuerValidator = $issuerValidator;
     }
 
     /**
      * @param bool $allowImplicitFlow
      */
-    public function setAllowImplicitFlow($allowImplicitFlow) {
+    public function setAllowImplicitFlow($allowImplicitFlow)
+    {
         $this->allowImplicitFlow = $allowImplicitFlow;
     }
 
@@ -1358,21 +1400,24 @@ class OpenIDConnectClient
      * @param array $array
      *        simple key => value
      */
-    public function providerConfigParam($array) {
+    public function providerConfigParam($array)
+    {
         $this->providerConfig = array_merge($this->providerConfig, $array);
     }
 
     /**
      * @param string $clientSecret
      */
-    public function setClientSecret($clientSecret) {
+    public function setClientSecret($clientSecret)
+    {
         $this->clientSecret = $clientSecret;
     }
 
     /**
      * @param string $clientID
      */
-    public function setClientID($clientID) {
+    public function setClientID($clientID)
+    {
         $this->clientID = $clientID;
     }
 
@@ -1382,11 +1427,12 @@ class OpenIDConnectClient
      *
      * @throws OpenIDConnectClientException
      */
-    public function register() {
+    public function register()
+    {
 
         $registration_endpoint = $this->getProviderConfigValue('registration_endpoint');
 
-        $send_object = (object ) array_merge($this->registrationParams, array(
+        $send_object = (object) array_merge($this->registrationParams, array(
             'redirect_uris' => array($this->getRedirectURL()),
             'client_name' => $this->getClientName()
         ));
@@ -1414,7 +1460,6 @@ class OpenIDConnectClient
             throw new OpenIDConnectClientException('Error registering:
                                                     Please contact the OpenID Connect provider and obtain a Client ID and Secret directly from them');
         }
-
     }
 
     /**
@@ -1428,7 +1473,8 @@ class OpenIDConnectClient
      * @return mixed
      * @throws OpenIDConnectClientException
      */
-    public function introspectToken($token, $token_type_hint = '', $clientId = null, $clientSecret = null) {
+    public function introspectToken($token, $token_type_hint = '', $clientId = null, $clientSecret = null)
+    {
         $introspection_endpoint = $this->getProviderConfigValue('introspection_endpoint');
 
         $post_data = array(
@@ -1442,8 +1488,10 @@ class OpenIDConnectClient
 
         // Convert token params to string format
         $post_params = http_build_query($post_data, '', '&');
-        $headers = ['Authorization: Basic ' . base64_encode(urlencode($clientId) . ':' . urlencode($clientSecret)),
-            'Accept: application/json'];
+        $headers = [
+            'Authorization: Basic ' . base64_encode(urlencode($clientId) . ':' . urlencode($clientSecret)),
+            'Accept: application/json'
+        ];
 
         return json_decode($this->fetchURL($introspection_endpoint, $post_params, $headers));
     }
@@ -1459,7 +1507,8 @@ class OpenIDConnectClient
      * @return mixed
      * @throws OpenIDConnectClientException
      */
-    public function revokeToken($token, $token_type_hint = '', $clientId = null, $clientSecret = null) {
+    public function revokeToken($token, $token_type_hint = '', $clientId = null, $clientSecret = null)
+    {
         $revocation_endpoint = $this->getProviderConfigValue('revocation_endpoint');
 
         $post_data = array(
@@ -1473,8 +1522,10 @@ class OpenIDConnectClient
 
         // Convert token params to string format
         $post_params = http_build_query($post_data, '', '&');
-        $headers = ['Authorization: Basic ' . base64_encode(urlencode($clientId) . ':' . urlencode($clientSecret)),
-            'Accept: application/json'];
+        $headers = [
+            'Authorization: Basic ' . base64_encode(urlencode($clientId) . ':' . urlencode($clientSecret)),
+            'Accept: application/json'
+        ];
 
         return json_decode($this->fetchURL($revocation_endpoint, $post_params, $headers));
     }
@@ -1482,35 +1533,40 @@ class OpenIDConnectClient
     /**
      * @return string
      */
-    public function getClientName() {
+    public function getClientName()
+    {
         return $this->clientName;
     }
 
     /**
      * @param string $clientName
      */
-    public function setClientName($clientName) {
+    public function setClientName($clientName)
+    {
         $this->clientName = $clientName;
     }
 
     /**
      * @return string
      */
-    public function getClientID() {
+    public function getClientID()
+    {
         return $this->clientID;
     }
 
     /**
      * @return string
      */
-    public function getClientSecret() {
+    public function getClientSecret()
+    {
         return $this->clientSecret;
     }
 
     /**
      * @return bool
      */
-    public function canVerifySignatures() {
+    public function canVerifySignatures()
+    {
         return class_exists('\phpseclib\Crypt\RSA') || class_exists('Crypt_RSA');
     }
 
@@ -1522,63 +1578,72 @@ class OpenIDConnectClient
      * @param string $accessToken
      * @return void
      */
-    public function setAccessToken($accessToken) {
+    public function setAccessToken($accessToken)
+    {
         $this->accessToken = $accessToken;
     }
 
     /**
      * @return string
      */
-    public function getAccessToken() {
+    public function getAccessToken()
+    {
         return $this->accessToken;
     }
 
     /**
      * @return string
      */
-    public function getRefreshToken() {
+    public function getRefreshToken()
+    {
         return $this->refreshToken;
     }
 
     /**
      * @return string
      */
-    public function getIdToken() {
+    public function getIdToken()
+    {
         return $this->idToken;
     }
 
     /**
      * @return object
      */
-    public function getAccessTokenHeader() {
+    public function getAccessTokenHeader()
+    {
         return $this->decodeJWT($this->accessToken);
     }
 
     /**
      * @return object
      */
-    public function getAccessTokenPayload() {
+    public function getAccessTokenPayload()
+    {
         return $this->decodeJWT($this->accessToken, 1);
     }
 
     /**
      * @return object
      */
-    public function getIdTokenHeader() {
+    public function getIdTokenHeader()
+    {
         return $this->decodeJWT($this->idToken);
     }
 
     /**
      * @return object
      */
-    public function getIdTokenPayload() {
+    public function getIdTokenPayload()
+    {
         return $this->decodeJWT($this->idToken, 1);
     }
 
     /**
      * @return string
      */
-    public function getTokenResponse() {
+    public function getTokenResponse()
+    {
         return $this->tokenResponse;
     }
 
@@ -1588,7 +1653,8 @@ class OpenIDConnectClient
      * @param string $nonce
      * @return string
      */
-    protected function setNonce($nonce) {
+    protected function setNonce($nonce)
+    {
         $this->setSessionKey('openid_connect_nonce', $nonce);
         return $nonce;
     }
@@ -1598,7 +1664,8 @@ class OpenIDConnectClient
      *
      * @return string
      */
-    protected function getNonce() {
+    protected function getNonce()
+    {
         return $this->getSessionKey('openid_connect_nonce');
     }
 
@@ -1607,7 +1674,8 @@ class OpenIDConnectClient
      *
      * @return void
      */
-    protected function unsetNonce() {
+    protected function unsetNonce()
+    {
         $this->unsetSessionKey('openid_connect_nonce');
     }
 
@@ -1617,7 +1685,8 @@ class OpenIDConnectClient
      * @param string $state
      * @return string
      */
-    protected function setState($state) {
+    protected function setState($state)
+    {
         $this->setSessionKey('openid_connect_state', $state);
         return $state;
     }
@@ -1627,7 +1696,8 @@ class OpenIDConnectClient
      *
      * @return string
      */
-    protected function getState() {
+    protected function getState()
+    {
         return $this->getSessionKey('openid_connect_state');
     }
 
@@ -1636,7 +1706,8 @@ class OpenIDConnectClient
      *
      * @return void
      */
-    protected function unsetState() {
+    protected function unsetState()
+    {
         $this->unsetSessionKey('openid_connect_state');
     }
 
@@ -1646,7 +1717,8 @@ class OpenIDConnectClient
      * @param string $codeVerifier
      * @return string
      */
-    protected function setCodeVerifier($codeVerifier) {
+    protected function setCodeVerifier($codeVerifier)
+    {
         $this->setSessionKey('openid_connect_code_verifier', $codeVerifier);
         return $codeVerifier;
     }
@@ -1656,7 +1728,8 @@ class OpenIDConnectClient
      *
      * @return string
      */
-    protected function getCodeVerifier() {
+    protected function getCodeVerifier()
+    {
         return $this->getSessionKey('openid_connect_code_verifier');
     }
 
@@ -1665,7 +1738,8 @@ class OpenIDConnectClient
      *
      * @return void
      */
-    protected function unsetCodeVerifier() {
+    protected function unsetCodeVerifier()
+    {
         $this->unsetSessionKey('openid_connect_code_verifier');
     }
 
@@ -1718,8 +1792,8 @@ class OpenIDConnectClient
      */
     private static function hashEquals($str1, $str2)
     {
-        $len1=static::safeLength($str1);
-        $len2=static::safeLength($str2);
+        $len1 = static::safeLength($str1);
+        $len2 = static::safeLength($str2);
 
         //compare strings without any early abort...
         $len = min($len1, $len2);
@@ -1735,31 +1809,36 @@ class OpenIDConnectClient
     /**
      * Use session to manage a nonce
      */
-    protected function startSession() {
+    protected function startSession()
+    {
         if (!isset($_SESSION)) {
             @session_start();
         }
     }
 
-    protected function commitSession() {
+    protected function commitSession()
+    {
         $this->startSession();
 
         session_write_close();
     }
 
-    protected function getSessionKey($key) {
+    protected function getSessionKey($key)
+    {
         $this->startSession();
 
         return $_SESSION[$key];
     }
 
-    protected function setSessionKey($key, $value) {
+    protected function setSessionKey($key, $value)
+    {
         $this->startSession();
 
         $_SESSION[$key] = $value;
     }
 
-    protected function unsetSessionKey($key) {
+    protected function unsetSessionKey($key)
+    {
         $this->startSession();
 
         unset($_SESSION[$key]);
@@ -1767,8 +1846,7 @@ class OpenIDConnectClient
 
     public function setUrlEncoding($curEncoding)
     {
-        switch ($curEncoding)
-        {
+        switch ($curEncoding) {
             case PHP_QUERY_RFC1738:
                 $this->enc_type = PHP_QUERY_RFC1738;
                 break;
@@ -1777,10 +1855,9 @@ class OpenIDConnectClient
                 $this->enc_type = PHP_QUERY_RFC3986;
                 break;
 
-        	default:
+            default:
                 break;
         }
-
     }
 
     /**
@@ -1826,14 +1903,16 @@ class OpenIDConnectClient
     /**
      * @return string
      */
-    public function getCodeChallengeMethod() {
+    public function getCodeChallengeMethod()
+    {
         return $this->codeChallengeMethod;
     }
 
     /**
      * @param string $codeChallengeMethod
      */
-    public function setCodeChallengeMethod($codeChallengeMethod) {
+    public function setCodeChallengeMethod($codeChallengeMethod)
+    {
         $this->codeChallengeMethod = $codeChallengeMethod;
     }
 }

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -307,11 +307,11 @@ class OpenIDConnectClient
                 throw new OpenIDConnectClientException('Got response: ' . $token_json->error);
             }
 
-	        // Sometime getState() return an empty string
+            // Sometime getState() return an empty string
             // and the authentication process fail
             if ($this->getState() == "")
                 $this->setState($_REQUEST['state']);
-
+            
             // Do an OpenID Connect session check
             if ($_REQUEST['state'] !== $this->getState()) {
                 throw new OpenIDConnectClientException('Unable to determine state');
@@ -350,7 +350,7 @@ class OpenIDConnectClient
                 $this->setNonce($claims->nonce);
                 user_error('Warning: Function getNonce return empty, setting in the session!');
             };
-
+            
             // If this is a valid claim
             if ($this->verifyJWTclaims($claims, $token_json->access_token)) {
 
@@ -467,7 +467,7 @@ class OpenIDConnectClient
                 'post_logout_redirect_uri' => $redirect);
         }
 
-        $signout_endpoint  .= (strpos($signout_endpoint, '?') === false ? '?' : '&') . http_build_query( $signout_params, null, '&', $this->enc_type);
+        $signout_endpoint  .= (strpos($signout_endpoint, '?') === false ? '?' : '&') . http_build_query( $signout_params, '', '&', $this->enc_type);
         $this->redirect($signout_endpoint);
     }
 
@@ -692,7 +692,7 @@ class OpenIDConnectClient
             ));
         }
 
-        $auth_endpoint .= (strpos($auth_endpoint, '?') === false ? '?' : '&') . http_build_query($auth_params, null, '&', $this->enc_type);
+        $auth_endpoint .= (strpos($auth_endpoint, '?') === false ? '?' : '&') . http_build_query($auth_params, '', '&', $this->enc_type);
 
         $this->commitSession();
         $this->redirect($auth_endpoint);
@@ -718,7 +718,7 @@ class OpenIDConnectClient
         );
 
         // Convert token params to string format
-        $post_params = http_build_query($post_data, null, '&', $this->enc_type);
+        $post_params = http_build_query($post_data, '', '&', $this->enc_type);
 
         return json_decode($this->fetchURL($token_endpoint, $post_params, $headers));
     }
@@ -753,7 +753,7 @@ class OpenIDConnectClient
         }
 
         // Convert token params to string format
-        $post_params = http_build_query($post_data, null, '&', $this->enc_type);
+        $post_params = http_build_query($post_data, '', '&', $this->enc_type);
 
         return json_decode($this->fetchURL($token_endpoint, $post_params, $headers));
     }
@@ -799,7 +799,7 @@ class OpenIDConnectClient
         }
 
         // Convert token params to string format
-        $token_params = http_build_query($token_params, null, '&', $this->enc_type);
+        $token_params = http_build_query($token_params, '', '&', $this->enc_type);
 
         $this->tokenResponse = json_decode($this->fetchURL($token_endpoint, $token_params, $headers));
 
@@ -826,7 +826,7 @@ class OpenIDConnectClient
         );
 
         // Convert token params to string format
-        $token_params = http_build_query($token_params, null, '&', $this->enc_type);
+        $token_params = http_build_query($token_params, '', '&', $this->enc_type);
 
         $json = json_decode($this->fetchURL($token_endpoint, $token_params));
 
@@ -1441,7 +1441,7 @@ class OpenIDConnectClient
         $clientSecret = $clientSecret !== null ? $clientSecret : $this->clientSecret;
 
         // Convert token params to string format
-        $post_params = http_build_query($post_data, null, '&');
+        $post_params = http_build_query($post_data, '', '&');
         $headers = ['Authorization: Basic ' . base64_encode(urlencode($clientId) . ':' . urlencode($clientSecret)),
             'Accept: application/json'];
 
@@ -1472,7 +1472,7 @@ class OpenIDConnectClient
         $clientSecret = $clientSecret !== null ? $clientSecret : $this->clientSecret;
 
         // Convert token params to string format
-        $post_params = http_build_query($post_data, null, '&');
+        $post_params = http_build_query($post_data, '', '&');
         $headers = ['Authorization: Basic ' . base64_encode(urlencode($clientId) . ':' . urlencode($clientSecret)),
             'Accept: application/json'];
 

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -430,23 +430,28 @@ class OpenIDConnectClient
      * Connect provider that the end-user has logged out of the relying party site
      * (the client application).
      *
-     * @param string $accessToken ID token (obtained at login)
+     * @param string $enduserIdentification ID token (obtained at login) or username for $method like as "login_hint"
      * @param string|null $redirect URL to which the RP is requesting that the End-User's User Agent
      * be redirected after a logout has been performed. The value MUST have been previously
      * registered with the OP. Value can be null.
+     * @param string $method The way of identifying the end-user for whom authentication is being requested.
+     * The default setting is "id_token_hint". There are two modes supported: "login_hint" and "id_token_hint"
      *
      * @throws OpenIDConnectClientException
      */
-    public function signOut($accessToken, $redirect) {
-        $signout_endpoint = $this->getProviderConfigValue('end_session_endpoint');
+    public function signOut($enduserIdentification, $redirect, $method = "id_token_hint") {
+        if (!in_array($method, array("id_token_hint", "login_hint")))
+            throw new OpenIDConnectClientException('method must be "id_token_hint" or "login_hint"');
+
+        $signout_endpoint = $this->getProviderConfigValue("end_session_endpoint");
 
         $signout_params = null;
         if($redirect === null){
-            $signout_params = array('id_token_hint' => $accessToken);
+            $signout_params = array($method => $enduserIdentification);
         }
         else {
             $signout_params = array(
-                'id_token_hint' => $accessToken,
+                $method => $enduserIdentification,
                 'post_logout_redirect_uri' => $redirect);
         }
 

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -307,7 +307,7 @@ class OpenIDConnectClient
                 throw new OpenIDConnectClientException('Got response: ' . $token_json->error);
             }
 
-	    // Sometime getState() return an empty string
+	        // Sometime getState() return an empty string
             // and the authentication process fail
             if ($this->getState() == "")
                 $this->setState($_REQUEST['state']);
@@ -343,6 +343,13 @@ class OpenIDConnectClient
 
             // Save the access token
             $this->accessToken = $token_json->access_token;
+
+            // During verifyJWTclaims sometime return an empty string (probably caused by the session timeout between KC and Client)
+            // Which cause issue in the *_auth.php, this should "patch" the randomic emptiness.
+            if ($this->getNonce() == "") {
+                $this->setNonce($claims->nonce);
+                user_error('Warning: Function getNonce return empty, setting in the session!');
+            };
 
             // If this is a valid claim
             if ($this->verifyJWTclaims($claims, $token_json->access_token)) {

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -307,6 +307,11 @@ class OpenIDConnectClient
                 throw new OpenIDConnectClientException('Got response: ' . $token_json->error);
             }
 
+	    // Sometime getState() return an empty string
+            // and the authentication process fail
+            if ($this->getState() == "")
+                $this->setState($_REQUEST['state']);
+
             // Do an OpenID Connect session check
             if ($_REQUEST['state'] !== $this->getState()) {
                 throw new OpenIDConnectClientException('Unable to determine state');

--- a/src/OpenIDConnectClient.php
+++ b/src/OpenIDConnectClient.php
@@ -307,6 +307,11 @@ class OpenIDConnectClient
                 throw new OpenIDConnectClientException('Got response: ' . $token_json->error);
             }
 
+            // Sometime getState() return an empty string
+            // and the authentication process fail
+            if ($this->getState() == "")
+                $this->setState($_REQUEST['state']);
+            
             // Do an OpenID Connect session check
             if ($_REQUEST['state'] !== $this->getState()) {
                 throw new OpenIDConnectClientException('Unable to determine state');


### PR DESCRIPTION
added one of the method client_id to logout as per KC logs events:
`Either the parameter 'client_id' or the parameter 'id_token_hint' is required when 'post_logout_redirect_uri' is used.`
